### PR TITLE
Add multitask experiment scripts and tests

### DIFF
--- a/multitask/README.md
+++ b/multitask/README.md
@@ -1,0 +1,17 @@
+# Multitask PFN Experiments
+
+This module contains lightweight utilities that make it easy to train and benchmark
+hierarchical-attention PFNs on synthetic multitask regression data.  The code mirrors
+the data generation process used in the multitask PFN project while relying on the
+latest TabPFNv2-style architecture that already ships in this repository.
+
+The entry points are:
+
+- `multitask.configs.build_multitask_main_config` – builds a `pfns.train.MainConfig`
+  tailored for multitask batches with hierarchical attention enabled.
+- `multitask.training_cli` – a small CLI for launching multitask PFN training runs.
+- `multitask.benchmark.run_runtime_benchmark` – helper to compare runtime and loss
+  across different numbers of tasks using the hierarchical attention flow.
+
+See the tests under `multitask/tests` for examples on how to compose the pieces
+programmatically.

--- a/multitask/__init__.py
+++ b/multitask/__init__.py
@@ -1,0 +1,15 @@
+"""Utilities for configuring and running multitask PFN experiments."""
+
+from .configs import (
+    MultitaskTrainingPlan,
+    build_multitask_main_config,
+    estimate_target_borders,
+)
+from .benchmark import run_runtime_benchmark
+
+__all__ = [
+    "MultitaskTrainingPlan",
+    "build_multitask_main_config",
+    "estimate_target_borders",
+    "run_runtime_benchmark",
+]

--- a/multitask/benchmark.py
+++ b/multitask/benchmark.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import statistics
+import time
+from dataclasses import replace
+from typing import Iterable
+
+import torch
+
+from pfns.priors import multitask_regression
+from pfns.train import compute_losses
+
+from .configs import MultitaskTrainingPlan, build_multitask_main_config
+
+
+def _run_single_pass(
+    model,
+    batch,
+    *,
+    single_eval_pos: int,
+    num_tasks: int | None,
+) -> torch.Tensor:
+    with torch.no_grad():
+        output = model(
+            x=batch.x,
+            y=batch.y[:, :single_eval_pos],
+            task_indices=batch.task_indices,
+            num_tasks=num_tasks,
+        )
+    return output
+
+
+def run_runtime_benchmark(
+    task_counts: Iterable[int],
+    *,
+    plan: MultitaskTrainingPlan | None = None,
+    warmup: int = 1,
+    runs: int = 3,
+    device: str | None = None,
+) -> dict[int, dict[str, float]]:
+    """Benchmark latency and loss across different task counts."""
+
+    if runs <= 0:
+        raise ValueError("runs must be positive")
+    if warmup < 0:
+        raise ValueError("warmup must be non-negative")
+
+    base_plan = plan or MultitaskTrainingPlan()
+    results: dict[int, dict[str, float]] = {}
+
+    for num_tasks in task_counts:
+        current_plan = base_plan.spawn_for_tasks(num_tasks)
+        if device is not None:
+            current_plan = replace(current_plan, device=device)
+
+        config = build_multitask_main_config(current_plan)
+        model = config.model.create_model().to(current_plan.device)
+        model.eval()
+
+        batch_shape = config.batch_shape_sampler.sample_batch_shape(epoch=0, step=0)
+        sampler_kwargs = batch_shape.as_get_batch_kwargs()
+        prior_kwargs = current_plan.prior_kwargs().copy()
+        # Avoid passing num_tasks twice when the sampler already specifies it.
+        if sampler_kwargs.get("num_tasks") is not None:
+            prior_kwargs.pop("num_tasks", None)
+
+        batch = multitask_regression.get_batch(
+            **sampler_kwargs,
+            **prior_kwargs,
+        )
+        batch.x = batch.x.to(current_plan.device)
+        batch.y = batch.y.to(current_plan.device)
+        batch.target_y = batch.target_y.to(current_plan.device)
+        if batch.task_indices is not None:
+            batch.task_indices = batch.task_indices.to(current_plan.device)
+
+        timings: list[float] = []
+        loss_values: list[float] = []
+
+        total_runs = warmup + runs
+        for idx in range(total_runs):
+            start = time.perf_counter()
+            output = _run_single_pass(
+                model,
+                batch,
+                single_eval_pos=batch_shape.single_eval_pos,
+                num_tasks=batch.num_tasks,
+            )
+            elapsed = time.perf_counter() - start
+            if idx >= warmup:
+                timings.append(elapsed)
+
+                targets = batch.target_y[:, batch_shape.single_eval_pos :]
+                losses = compute_losses(
+                    output,
+                    targets,
+                    model.criterion,
+                    n_targets_per_input=1,
+                )
+                loss_values.append(losses.mean().item())
+
+        results[num_tasks] = {
+            "mean_latency": statistics.mean(timings) if timings else 0.0,
+            "stdev_latency": statistics.pstdev(timings) if len(timings) > 1 else 0.0,
+            "mean_loss": statistics.mean(loss_values) if loss_values else float("nan"),
+        }
+
+    return results
+
+
+__all__ = ["run_runtime_benchmark"]

--- a/multitask/configs.py
+++ b/multitask/configs.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field, replace
+from typing import Sequence
+
+import torch
+
+from pfns.batch_shape_sampler import BatchShapeSamplerConfig
+from pfns.model.criterions import BarDistributionConfig
+from pfns.model.transformer_config import TransformerConfig
+from pfns.optimizer import OptimizerConfig
+from pfns.priors.prior import AdhocPriorConfig
+from pfns.train import MainConfig
+from pfns.utils import default_device
+
+from pfns.priors import multitask_regression
+
+
+@dataclass(frozen=True)
+class MultitaskTrainingPlan:
+    """Configuration helper for multitask PFN experiments.
+
+    The defaults intentionally mirror the settings used in the multitask PFN paper
+    while keeping the values small enough for unit tests and quick smoke runs.
+    """
+
+    num_tasks: int = 5
+    batch_size: int = 8
+    seq_len: int = 64
+    single_eval_pos: int = 48
+    num_features: int = 8
+    steps_per_epoch: int = 25
+    epochs: int = 5
+    lr: float = 3e-4
+    weight_decay: float = 0.0
+    emsize: int = 128
+    nlayers: int = 4
+    nhead: int = 4
+    nhid: int = 512
+    features_per_group: int = 1
+    attention_between_features: bool = True
+    use_task_summary_projection: bool = True
+    train_mixed_precision: bool = False
+    device: str = default_device
+
+    # Prior hyperparameters
+    weight_std: float = 1.0
+    task_offset_std: float = 0.5
+    bias_std: float = 0.1
+    observation_noise: float = 0.05
+
+    # Histogram estimation for the bar distribution criterion
+    num_histogram_buckets: int = 32
+    sample_batches_for_borders: int = 16
+
+    # Optional overrides
+    model_extra_args: dict | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:  # type: ignore[override]
+        if self.seq_len <= self.single_eval_pos:
+            raise ValueError(
+                "seq_len must be strictly larger than single_eval_pos so that a test "
+                "segment exists."
+            )
+        if self.num_tasks <= 0:
+            raise ValueError("num_tasks must be positive.")
+        if self.seq_len <= 0 or self.single_eval_pos <= 0:
+            raise ValueError("seq_len and single_eval_pos must be positive.")
+        if self.num_histogram_buckets < 2:
+            raise ValueError("num_histogram_buckets must be at least 2.")
+        if self.sample_batches_for_borders <= 0:
+            raise ValueError("sample_batches_for_borders must be positive.")
+        if self.nhead <= 0 or self.emsize % self.nhead != 0:
+            raise ValueError("nhead must divide emsize.")
+
+    def spawn_for_tasks(self, num_tasks: int) -> MultitaskTrainingPlan:
+        """Return a copy of the plan with a different number of tasks."""
+
+        return replace(self, num_tasks=num_tasks)
+
+    def prior_kwargs(self) -> dict:
+        """Keyword arguments for the multitask prior helper."""
+
+        return {
+            "num_tasks": self.num_tasks,
+            "weight_std": self.weight_std,
+            "task_offset_std": self.task_offset_std,
+            "bias_std": self.bias_std,
+            "observation_noise": self.observation_noise,
+            "device": self.device,
+        }
+
+
+def _multitask_prior_kwargs(plan: MultitaskTrainingPlan) -> dict:
+    return plan.prior_kwargs()
+
+
+def estimate_target_borders(plan: MultitaskTrainingPlan) -> Sequence[float]:
+    """Estimate target value borders for the bar distribution criterion."""
+
+    get_batch = multitask_regression.get_batch
+    collected: list[torch.Tensor] = []
+
+    for sample_idx in range(plan.sample_batches_for_borders):
+        batch = get_batch(
+            batch_size=plan.batch_size,
+            seq_len=plan.seq_len,
+            num_features=plan.num_features,
+            single_eval_pos=plan.single_eval_pos,
+            **_multitask_prior_kwargs(plan),
+        )
+        test_targets = batch.target_y[:, plan.single_eval_pos :]
+        if test_targets.numel() == 0:
+            continue
+        collected.append(test_targets.reshape(-1))
+        if collected and collected[-1].isnan().any():
+            raise ValueError("Encountered NaNs while sampling multitask targets.")
+
+    if not collected:
+        raise RuntimeError("Unable to collect any targets for estimating borders.")
+
+    concatenated = torch.cat(collected)
+    quantiles = torch.linspace(0.0, 1.0, plan.num_histogram_buckets + 1, device=concatenated.device)
+    borders = torch.quantile(concatenated, quantiles, interpolation="linear")
+    borders = torch.unique_consecutive(borders)
+
+    if borders.numel() < 2:
+        # Fallback to a symmetric interval around the observed mean
+        mean = concatenated.mean().item()
+        std = concatenated.std(unbiased=False).item() or 1.0
+        half_width = max(1.0, 3.0 * std)
+        borders = torch.tensor([mean - half_width, mean + half_width], device=concatenated.device)
+
+    if not torch.isfinite(borders).all():
+        raise ValueError("Non-finite values encountered while estimating borders.")
+
+    return borders.cpu().tolist()
+
+
+def build_multitask_main_config(plan: MultitaskTrainingPlan) -> MainConfig:
+    """Create a `MainConfig` tailored for multitask hierarchical attention."""
+
+    borders = estimate_target_borders(plan)
+
+    prior_config = AdhocPriorConfig(
+        prior_names=["multitask_regression"],
+        prior_kwargs=_multitask_prior_kwargs(plan),
+    )
+
+    criterion_config = BarDistributionConfig(borders=borders, full_support=True)
+
+    transformer_config = TransformerConfig(
+        criterion=criterion_config,
+        emsize=plan.emsize,
+        nhid=plan.nhid,
+        nlayers=plan.nlayers,
+        nhead=plan.nhead,
+        features_per_group=plan.features_per_group,
+        attention_between_features=plan.attention_between_features,
+        use_hierarchical_attention=True,
+        use_task_summary_projection=plan.use_task_summary_projection,
+        model_extra_args=plan.model_extra_args,
+    )
+
+    batch_sampler = BatchShapeSamplerConfig(
+        batch_size=plan.batch_size,
+        min_single_eval_pos=plan.single_eval_pos,
+        max_seq_len=plan.seq_len + 1,
+        min_num_features=plan.num_features,
+        max_num_features=plan.num_features,
+        fixed_num_test_instances=plan.seq_len - plan.single_eval_pos,
+        min_num_tasks=plan.num_tasks,
+        max_num_tasks=plan.num_tasks,
+    )
+
+    optimizer_config = OptimizerConfig(
+        optimizer="adamw",
+        lr=plan.lr,
+        weight_decay=plan.weight_decay,
+    )
+
+    return MainConfig(
+        priors=[prior_config],
+        optimizer=optimizer_config,
+        model=transformer_config,
+        batch_shape_sampler=batch_sampler,
+        epochs=plan.epochs,
+        steps_per_epoch=plan.steps_per_epoch,
+        train_mixed_precision=plan.train_mixed_precision,
+        scheduler="constant",
+        warmup_epochs=max(1, math.ceil(plan.epochs / 10)),
+        n_targets_per_input=1,
+        num_workers=0,
+        progress_bar=False,
+    )
+
+
+__all__ = [
+    "MultitaskTrainingPlan",
+    "estimate_target_borders",
+    "build_multitask_main_config",
+]

--- a/multitask/tests/__init__.py
+++ b/multitask/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test helpers for the multitask experiment utilities."""

--- a/multitask/tests/test_benchmark.py
+++ b/multitask/tests/test_benchmark.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import torch
+
+from multitask.benchmark import run_runtime_benchmark
+from multitask.configs import MultitaskTrainingPlan
+
+
+def _benchmark_plan() -> MultitaskTrainingPlan:
+    return MultitaskTrainingPlan(
+        num_tasks=3,
+        batch_size=2,
+        seq_len=28,
+        single_eval_pos=18,
+        num_features=3,
+        steps_per_epoch=2,
+        epochs=1,
+        lr=1e-3,
+        weight_decay=0.0,
+        emsize=32,
+        nhid=64,
+        nlayers=2,
+        nhead=4,
+        num_histogram_buckets=8,
+        sample_batches_for_borders=3,
+        device="cpu",
+    )
+
+
+def test_runtime_benchmark_returns_latency_and_loss():
+    torch.manual_seed(123)
+    plan = _benchmark_plan()
+    results = run_runtime_benchmark([3, 5], plan=plan, warmup=0, runs=1, device="cpu")
+
+    assert set(results.keys()) == {3, 5}
+    for metrics in results.values():
+        assert metrics["mean_latency"] >= 0.0
+        assert "mean_loss" in metrics
+        assert not torch.isnan(torch.tensor(metrics["mean_loss"]))

--- a/multitask/tests/test_configs.py
+++ b/multitask/tests/test_configs.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import torch
+
+from multitask.configs import (
+    MultitaskTrainingPlan,
+    build_multitask_main_config,
+    estimate_target_borders,
+)
+
+
+def _small_plan(num_tasks: int = 3) -> MultitaskTrainingPlan:
+    return MultitaskTrainingPlan(
+        num_tasks=num_tasks,
+        batch_size=2,
+        seq_len=32,
+        single_eval_pos=20,
+        num_features=4,
+        steps_per_epoch=2,
+        epochs=1,
+        lr=1e-3,
+        weight_decay=0.0,
+        emsize=32,
+        nhid=64,
+        nlayers=2,
+        nhead=4,
+        num_histogram_buckets=8,
+        sample_batches_for_borders=4,
+        train_mixed_precision=False,
+        device="cpu",
+    )
+
+
+def test_build_multitask_main_config_generates_valid_config():
+    torch.manual_seed(0)
+    plan = _small_plan(num_tasks=3)
+    config = build_multitask_main_config(plan)
+
+    assert config.model.use_hierarchical_attention is True
+    assert config.batch_shape_sampler.min_num_tasks == plan.num_tasks
+    assert config.batch_shape_sampler.max_num_tasks == plan.num_tasks
+
+    get_batch = config.priors[0].create_get_batch_method()
+    batch = get_batch(
+        batch_size=plan.batch_size,
+        seq_len=plan.seq_len,
+        num_features=plan.num_features,
+        single_eval_pos=plan.single_eval_pos,
+    )
+
+    assert batch.task_indices is not None
+    assert batch.task_indices.min().item() >= -1
+    assert batch.task_indices.max().item() < plan.num_tasks
+    assert batch.num_tasks == plan.num_tasks
+
+
+def test_estimate_target_borders_is_sorted_and_finite():
+    torch.manual_seed(0)
+    plan = _small_plan(num_tasks=4)
+    borders = estimate_target_borders(plan)
+
+    assert len(borders) >= 2
+    assert all(torch.isfinite(torch.tensor(borders)))
+    assert borders == sorted(borders)

--- a/multitask/training_cli.py
+++ b/multitask/training_cli.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from pfns.train import MainConfig, train as run_training_loop
+from pfns.utils import default_device
+
+from .configs import MultitaskTrainingPlan, build_multitask_main_config
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Train a hierarchical multitask PFN using the built-in trainer.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--num-tasks", type=int, default=5, help="Number of tasks per batch.")
+    parser.add_argument("--batch-size", type=int, default=8, help="Number of task datasets per batch.")
+    parser.add_argument("--seq-len", type=int, default=64, help="Total sequence length (train + test).")
+    parser.add_argument("--single-eval-pos", type=int, default=48, help="Training sequence length inside each dataset.")
+    parser.add_argument("--num-features", type=int, default=8, help="Number of features per task dataset.")
+    parser.add_argument("--epochs", type=int, default=5, help="Number of epochs for training.")
+    parser.add_argument("--steps-per-epoch", type=int, default=25, help="Steps per epoch for the trainer.")
+    parser.add_argument("--lr", type=float, default=3e-4, help="Learning rate for AdamW.")
+    parser.add_argument("--weight-decay", type=float, default=0.0, help="Weight decay for AdamW.")
+    parser.add_argument("--emsize", type=int, default=128, help="Embedding dimension of the transformer.")
+    parser.add_argument("--nhid", type=int, default=512, help="Hidden size of the feed-forward network.")
+    parser.add_argument("--nlayers", type=int, default=4, help="Number of transformer layers.")
+    parser.add_argument("--nhead", type=int, default=4, help="Number of attention heads.")
+    parser.add_argument(
+        "--features-per-group",
+        type=int,
+        default=1,
+        help="Number of features grouped together for column-wise attention.",
+    )
+    parser.add_argument(
+        "--disable-feature-attention",
+        action="store_true",
+        help="Disable between-feature attention (reverts to per-feature processing).",
+    )
+    parser.add_argument(
+        "--no-summary-projection",
+        action="store_true",
+        help="Disable the learnable projection on task summary tokens.",
+    )
+    parser.add_argument(
+        "--histogram-buckets",
+        type=int,
+        default=32,
+        help="Number of histogram buckets for the bar distribution criterion.",
+    )
+    parser.add_argument(
+        "--border-samples",
+        type=int,
+        default=16,
+        help="Number of synthetic batches to sample when estimating histogram borders.",
+    )
+    parser.add_argument(
+        "--train-mixed-precision",
+        action="store_true",
+        help="Enable mixed precision training.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Device to use for sampling and training (defaults to detected device).",
+    )
+    parser.add_argument(
+        "--config-out",
+        type=Path,
+        default=None,
+        help="Optional path to save the generated config in YAML format.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the config and exit without launching training.",
+    )
+    return parser
+
+
+def plan_from_args(args: argparse.Namespace) -> MultitaskTrainingPlan:
+    device = args.device or default_device
+    return MultitaskTrainingPlan(
+        num_tasks=args.num_tasks,
+        batch_size=args.batch_size,
+        seq_len=args.seq_len,
+        single_eval_pos=args.single_eval_pos,
+        num_features=args.num_features,
+        epochs=args.epochs,
+        steps_per_epoch=args.steps_per_epoch,
+        lr=args.lr,
+        weight_decay=args.weight_decay,
+        emsize=args.emsize,
+        nhid=args.nhid,
+        nlayers=args.nlayers,
+        nhead=args.nhead,
+        features_per_group=args.features_per_group,
+        attention_between_features=not args.disable_feature_attention,
+        use_task_summary_projection=not args.no_summary_projection,
+        train_mixed_precision=args.train_mixed_precision,
+        num_histogram_buckets=args.histogram_buckets,
+        sample_batches_for_borders=args.border_samples,
+        device=device,
+    )
+
+
+def run_from_plan(plan: MultitaskTrainingPlan, *, dry_run: bool = False) -> MainConfig:
+    config = build_multitask_main_config(plan)
+    if not dry_run:
+        run_training_loop(config, device=plan.device)
+    return config
+
+
+def main(argv: Sequence[str] | None = None) -> MainConfig:
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    plan = plan_from_args(args)
+    config = build_multitask_main_config(plan)
+
+    if args.config_out is not None:
+        args.config_out.parent.mkdir(parents=True, exist_ok=True)
+        args.config_out.write_text(config.to_yaml())
+        print(f"Wrote multitask config to {args.config_out}")
+
+    if args.dry_run:
+        print("Dry run requested; skipping training.")
+        return config
+
+    run_training_loop(config, device=plan.device)
+    return config
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/pfns/model/transformer_config.py
+++ b/pfns/model/transformer_config.py
@@ -29,6 +29,8 @@ class TransformerConfig(base_config.BaseConfig):
     features_per_group: int = 1
     attention_between_features: bool = True
     model_extra_args: tp.Dict[str, base_config.BaseTypes] | None = None
+    use_hierarchical_attention: bool = False
+    use_task_summary_projection: bool = True
 
     def create_model(self) -> transformer.TableTransformer:
         # Resolve criterion
@@ -81,6 +83,8 @@ class TransformerConfig(base_config.BaseConfig):
             style_encoder=style_encoder,
             y_style_encoder=y_style_encoder,
             batch_first=True,  # model is batch_first by default now
+            use_hierarchical_attention=self.use_hierarchical_attention,
+            use_task_summary_projection=self.use_task_summary_projection,
             **(self.model_extra_args or {}),
         )
         model.criterion = criterion

--- a/pfns/priors/multitask_regression.py
+++ b/pfns/priors/multitask_regression.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+from pfns.priors.prior import Batch
+from pfns.utils import default_device
+
+
+@dataclass
+class MultiTaskPriorConfig:
+    """Lightweight configuration container for the multitask regression prior."""
+
+    num_tasks: int
+    weight_std: float = 1.0
+    task_offset_std: float = 0.5
+    bias_std: float = 0.1
+    observation_noise: float = 0.05
+    device: str = default_device
+
+    def create_get_batch_method(self):
+        def _get_batch(**kwargs):
+            return get_batch(
+                **kwargs,
+                num_tasks=self.num_tasks,
+                weight_std=self.weight_std,
+                task_offset_std=self.task_offset_std,
+                bias_std=self.bias_std,
+                observation_noise=self.observation_noise,
+                device=self.device,
+            )
+
+        return _get_batch
+
+
+def _allocate_counts(total: int, num_tasks: int, device: torch.device) -> torch.Tensor:
+    if total <= 0:
+        return torch.zeros(num_tasks, dtype=torch.long, device=device)
+
+    if total >= num_tasks:
+        base = total // num_tasks
+        counts = torch.full((num_tasks,), base, dtype=torch.long, device=device)
+        remainder = total % num_tasks
+        if remainder:
+            counts[:remainder] += 1
+        return counts
+
+    counts = torch.zeros(num_tasks, dtype=torch.long, device=device)
+    counts[:total] = 1
+    return counts
+
+
+@torch.no_grad()
+def get_batch(
+    *,
+    batch_size: int,
+    seq_len: int,
+    num_features: int,
+    single_eval_pos: Optional[int],
+    num_tasks: Optional[int] = None,
+    device: str = default_device,
+    weight_std: float = 1.0,
+    task_offset_std: float = 0.5,
+    bias_std: float = 0.1,
+    observation_noise: float = 0.05,
+    **_: object,
+) -> Batch:
+    """Sample a batch of multitask regression problems."""
+
+    if single_eval_pos is None:
+        raise ValueError("single_eval_pos must be provided for multitask batches.")
+
+    if num_tasks is None:
+        num_tasks = 1
+
+    if num_tasks <= 0:
+        raise ValueError("num_tasks must be positive.")
+
+    torch_device = torch.device(device)
+
+    x = torch.randn(batch_size, seq_len, num_features, device=torch_device)
+    y = torch.zeros(batch_size, seq_len, 1, device=torch_device)
+    target_y = torch.zeros_like(y)
+    task_index_tensor = torch.full(
+        (batch_size, seq_len), -1, dtype=torch.long, device=torch_device
+    )
+
+    test_len = seq_len - single_eval_pos
+
+    for batch_id in range(batch_size):
+        shared_weight = torch.randn(num_features, 1, device=torch_device) * weight_std
+        task_weights = shared_weight.unsqueeze(0).repeat(num_tasks, 1, 1)
+        task_weights += torch.randn_like(task_weights) * task_offset_std
+        task_bias = torch.randn(num_tasks, 1, device=torch_device) * bias_std
+
+        train_counts = _allocate_counts(single_eval_pos, num_tasks, torch_device)
+        test_counts = _allocate_counts(test_len, num_tasks, torch_device)
+
+        task_order = torch.randperm(num_tasks, device=torch_device)
+
+        train_ids = []
+        for task_id in task_order:
+            count = int(train_counts[task_id].item())
+            if count == 0:
+                continue
+            train_ids.append(torch.full((count,), task_id.item(), device=torch_device))
+        if train_ids:
+            train_ids = torch.cat(train_ids)
+            train_ids = train_ids[torch.randperm(train_ids.numel(), device=torch_device)]
+        else:
+            train_ids = torch.empty(0, dtype=torch.long, device=torch_device)
+
+        test_ids = []
+        for task_id in task_order:
+            count = int(test_counts[task_id].item())
+            if count == 0:
+                continue
+            test_ids.append(torch.full((count,), task_id.item(), device=torch_device))
+        if test_ids:
+            test_ids = torch.cat(test_ids)
+            test_ids = test_ids[torch.randperm(test_ids.numel(), device=torch_device)]
+        else:
+            test_ids = torch.empty(0, dtype=torch.long, device=torch_device)
+
+        all_ids = torch.cat((train_ids, test_ids))
+        if all_ids.numel() != seq_len:
+            padding = seq_len - all_ids.numel()
+            if padding > 0:
+                pad_ids = torch.full((padding,), -1, device=torch_device)
+                all_ids = torch.cat((all_ids, pad_ids))
+            else:
+                all_ids = all_ids[:seq_len]
+
+        task_index_tensor[batch_id] = all_ids
+
+        for task_id in range(num_tasks):
+            mask = all_ids == task_id
+            if not bool(mask.any()):
+                continue
+            outputs = x[batch_id, mask] @ task_weights[task_id]
+            outputs = outputs + task_bias[task_id]
+            y[batch_id, mask, 0] = outputs.squeeze(-1)
+
+        noise = torch.randn_like(y[batch_id]) * observation_noise
+        y[batch_id] += noise
+        target_y[batch_id] = y[batch_id]
+
+    return Batch(
+        x=x,
+        y=y,
+        target_y=target_y,
+        single_eval_pos=single_eval_pos,
+        task_indices=task_index_tensor,
+        num_tasks=num_tasks,
+    )

--- a/pfns/priors/prior.py
+++ b/pfns/priors/prior.py
@@ -82,6 +82,8 @@ class Batch:
     )
     info_used_with_gradient_magnitudes: Optional[dict] = None
     gradient_multipliers: Optional[torch.Tensor] = None
+    task_indices: Optional[torch.Tensor] = None
+    num_tasks: Optional[int] = None
 
     def other_filled_attributes(
         self, set_of_attributes: Set[str] = frozenset(("x", "y", "target_y"))

--- a/pfns/train.py
+++ b/pfns/train.py
@@ -459,6 +459,11 @@ def train_or_evaluate_epoch(
             time_to_get_batch = time.time() - before_get_batch
             before_forward = time.time()
             try:
+                task_indices = (
+                    batch.task_indices.to(device)
+                    if batch.task_indices is not None
+                    else None
+                )
                 with autocast(device.split(":")[0], enabled=scaler is not None):
                     output = model(
                         x=batch.x.to(device),
@@ -467,6 +472,8 @@ def train_or_evaluate_epoch(
                         y_style=move_y_style_and_check_shape(
                             batch.y_style, batch.y, device
                         ),
+                        task_indices=task_indices,
+                        num_tasks=batch.num_tasks,
                         only_return_standard_out=True,
                     )  # shape: (batch_size, test_len)
 

--- a/tests/priors/test_multitask_prior.py
+++ b/tests/priors/test_multitask_prior.py
@@ -1,0 +1,23 @@
+import torch
+
+from pfns.priors import multitask_regression
+
+
+def test_multitask_prior_shapes():
+    batch = multitask_regression.get_batch(
+        batch_size=2,
+        seq_len=12,
+        num_features=4,
+        single_eval_pos=7,
+        num_tasks=3,
+    )
+
+    assert batch.x.shape == (2, 12, 4)
+    assert batch.y.shape == (2, 12, 1)
+    assert batch.task_indices is not None
+    assert batch.num_tasks == 3
+    assert batch.task_indices.shape == (2, 12)
+    train_task_ids = batch.task_indices[:, :7]
+    assert torch.all(train_task_ids >= 0)
+    test_task_ids = batch.task_indices[:, 7:]
+    assert torch.all(test_task_ids >= -1)


### PR DESCRIPTION
## Summary
- introduce a `multitask` package with configuration helpers, training CLI, and runtime benchmark utilities for hierarchical attention experiments
- document the new workflow and expose helpers through a dedicated README and package exports
- add focused tests that validate config generation, border estimation, and runtime benchmarking on synthetic multitask batches

## Testing
- PYTHONPATH=. pytest multitask/tests tests/model/test_transformer.py::test_transformer_hierarchical_attention tests/priors/test_multitask_prior.py

------
https://chatgpt.com/codex/tasks/task_e_68d01a9a2f908327859f232f7ec1510d