### PR TITLE
Improve MTGP jittered Cholesky fallback

### DIFF
--- a/pfns/model/transformer_config.py
+++ b/pfns/model/transformer_config.py
@@ -28,6 +28,7 @@ class TransformerConfig(base_config.BaseConfig):
     nhead: int = 2
     features_per_group: int = 1
     attention_between_features: bool = True
+    use_task_hierarchy: bool = False
     model_extra_args: tp.Dict[str, base_config.BaseTypes] | None = None
 
     def create_model(self) -> transformer.TableTransformer:
@@ -78,6 +79,7 @@ class TransformerConfig(base_config.BaseConfig):
             nlayers=self.nlayers,
             nhead=self.nhead,
             attention_between_features=self.attention_between_features,
+            use_task_hierarchy=self.use_task_hierarchy,
             style_encoder=style_encoder,
             y_style_encoder=y_style_encoder,
             batch_first=True,  # model is batch_first by default now

--- a/pfns/priors/multi_task_gp.py
+++ b/pfns/priors/multi_task_gp.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+from torch.distributions import LKJCholesky, MultivariateNormal
+
+from pfns.utils import default_device
+
+from .prior import Batch
+
+
+def _sample_task_covariance(
+    num_tasks: int,
+    *,
+    device: torch.device,
+    concentration: float,
+) -> torch.Tensor:
+    cholesky = LKJCholesky(num_tasks, concentration=concentration).sample().to(device)
+    corr = cholesky @ cholesky.T
+    scales = torch.distributions.Gamma(2.0, 1.0).sample((num_tasks,)).to(device)
+    scale_matrix = torch.diag(scales.sqrt())
+    return scale_matrix @ corr @ scale_matrix
+
+
+def _ensure_cholesky(
+    matrix: torch.Tensor,
+    jitter: float = 1e-5,
+    max_tries: int = 6,
+) -> torch.Tensor:
+    """Return a stable Cholesky factor for the provided covariance matrix.
+
+    Numerical noise can make the sampled kernel non positive-definite, so we
+    symmetrize the matrix and add diagonal jitter until decomposition succeeds.
+    """
+
+    eye = torch.eye(matrix.shape[0], device=matrix.device, dtype=matrix.dtype)
+    attempt = (matrix + matrix.transpose(0, 1)) / 2
+    for _ in range(max_tries):
+        chol, info = torch.linalg.cholesky_ex(attempt)
+        if int(info.item()) == 0:
+            return chol
+        attempt = attempt + jitter * eye
+        jitter *= 10
+
+    raise RuntimeError("Failed to compute a valid Cholesky factor for task covariance")
+
+
+@torch.no_grad()
+def get_batch(
+    batch_size: int,
+    seq_len: int,
+    num_features: int,
+    *,
+    single_eval_pos: int,
+    device: torch.device = default_device,
+    min_tasks: int = 2,
+    max_tasks: int = 5,
+    task_eta: float = 2.0,
+    p_unrelated: float = 0.2,
+    lengthscale_range: Tuple[float, float] = (0.3, 1.5),
+    noise_scale: float = 0.05,
+    **_: object,
+) -> Batch:
+    if min_tasks < 1 or max_tasks < min_tasks:
+        raise ValueError("Invalid task range provided")
+
+    x = torch.randn(batch_size, seq_len, num_features, device=device)
+    y = torch.zeros(batch_size, seq_len, 1, device=device)
+    target_y = torch.zeros_like(y)
+    task_partition = torch.zeros(batch_size, seq_len, dtype=torch.long, device=device)
+
+    for batch_idx in range(batch_size):
+        num_tasks = torch.randint(min_tasks, max_tasks + 1, (1,), device=device).item()
+        tasks = torch.randint(0, num_tasks, (seq_len,), device=device)
+        for task_id in range(num_tasks):
+            if (tasks == task_id).sum() == 0:
+                tasks[task_id % seq_len] = task_id
+        task_partition[batch_idx] = tasks
+
+        lengthscale = torch.empty(1, device=device).uniform_(*lengthscale_range).item()
+        diffs = x[batch_idx].unsqueeze(1) - x[batch_idx].unsqueeze(0)
+        sqdist = diffs.pow(2).sum(-1)
+        kernel_x = torch.exp(-0.5 * sqdist / (lengthscale**2))
+
+        task_cov = _sample_task_covariance(
+            num_tasks,
+            device=device,
+            concentration=task_eta,
+        )
+
+        if torch.rand(1, device=device).item() < p_unrelated:
+            unrelated = torch.rand(num_tasks, device=device) < 0.5
+            if unrelated.all():
+                unrelated[torch.randint(0, num_tasks, (1,), device=device).item()] = False
+            for idx, flag in enumerate(unrelated.tolist()):
+                if flag:
+                    task_cov[idx, :] = 0
+                    task_cov[:, idx] = 0
+                    task_cov[idx, idx] = torch.clamp(task_cov[idx, idx], min=1e-3)
+
+        cov_latent = torch.zeros(seq_len, seq_len, device=device)
+        for i in range(seq_len):
+            cov_latent[i] = task_cov[tasks[i], tasks] * kernel_x[i]
+
+        cov_latent = cov_latent + 1e-5 * torch.eye(seq_len, device=device)
+        chol = _ensure_cholesky(cov_latent)
+        mvn = MultivariateNormal(
+            torch.zeros(seq_len, device=device),
+            scale_tril=chol,
+        )
+        latent = mvn.sample()
+        observed = latent + noise_scale * torch.randn(seq_len, device=device)
+
+        y[batch_idx, :, 0] = observed
+        target_y[batch_idx, :, 0] = latent
+
+    return Batch(
+        x=x,
+        y=y,
+        target_y=target_y,
+        task_partition=task_partition,
+        single_eval_pos=single_eval_pos,
+    )
+

--- a/pfns/priors/prior.py
+++ b/pfns/priors/prior.py
@@ -74,6 +74,7 @@ class Batch:
     # Optional Batch Entries
     style: Optional[torch.Tensor] = None
     y_style: Optional[torch.Tensor] = None
+    task_partition: Optional[torch.Tensor] = None
     style_hyperparameter_values: Optional[torch.Tensor] = None
     single_eval_pos: Optional[torch.Tensor] = None
     causal_model_dag: Optional[object] = None

--- a/pfns/train.py
+++ b/pfns/train.py
@@ -25,6 +25,7 @@ from .priors import data_loading, prior, utils as priors_utils
 from .training_utils import (
     Metrics,
     move_style_and_check_shape,
+    move_task_partition_and_check_shape,
     move_y_style_and_check_shape,
     set_model_to,
     update_importance_sampling_infos,
@@ -466,6 +467,9 @@ def train_or_evaluate_epoch(
                         style=move_style_and_check_shape(batch.style, batch.x, device),
                         y_style=move_y_style_and_check_shape(
                             batch.y_style, batch.y, device
+                        ),
+                        task_partition=move_task_partition_and_check_shape(
+                            batch.task_partition, batch.x, device
                         ),
                         only_return_standard_out=True,
                     )  # shape: (batch_size, test_len)

--- a/pfns/training_utils.py
+++ b/pfns/training_utils.py
@@ -164,3 +164,22 @@ def move_style_and_check_shape(
                 f"and {x.shape=}"
             )
     return style
+
+
+def move_task_partition_and_check_shape(
+    task_partition: torch.Tensor | None, x: torch.Tensor, device: torch.device
+) -> torch.Tensor | None:
+    if task_partition is None:
+        return None
+
+    if task_partition.dim() != 2:
+        raise ValueError(
+            "task_partition must be a 2D tensor of shape (batch, seq_len)"
+        )
+
+    if task_partition.shape[0] != x.shape[0] or task_partition.shape[1] != x.shape[1]:
+        raise ValueError(
+            "task_partition must match the batch and sequence dimensions of x"
+        )
+
+    return task_partition.to(device).long()

--- a/tests/test_hierarchical_transformer.py
+++ b/tests/test_hierarchical_transformer.py
@@ -1,0 +1,58 @@
+import pytest
+import torch
+
+from pfns.model.transformer import TableTransformer
+
+
+def test_hierarchical_forward_shape_and_gradients():
+    torch.manual_seed(0)
+    model = TableTransformer(
+        ninp=16,
+        nhid=32,
+        nlayers=2,
+        nhead=4,
+        features_per_group=1,
+        use_task_hierarchy=True,
+    )
+
+    batch_size = 2
+    seq_len = 6
+    single_eval_pos = 3
+    num_features = 4
+
+    x = torch.randn(batch_size, seq_len, num_features, requires_grad=True)
+    y = torch.randn(batch_size, single_eval_pos, 1)
+    task_partition = torch.tensor(
+        [[0, 0, 0, 1, 1, 1], [1, 1, 0, 0, 2, 2]],
+        dtype=torch.long,
+    )
+
+    output = model(
+        x=x,
+        y=y,
+        task_partition=task_partition,
+        only_return_standard_out=True,
+    )
+
+    assert output.shape[0] == batch_size
+    assert output.shape[1] == seq_len - single_eval_pos
+    assert output.shape[2] == 1
+
+    output.sum().backward()
+    assert x.grad is not None
+
+
+def test_hierarchical_requires_partition():
+    model = TableTransformer(
+        ninp=8,
+        nhid=16,
+        nlayers=1,
+        nhead=2,
+        features_per_group=1,
+        use_task_hierarchy=True,
+    )
+    x = torch.randn(1, 4, 3)
+    y = torch.randn(1, 2, 1)
+    with pytest.raises(ValueError):
+        model(x=x, y=y, only_return_standard_out=True)
+

--- a/tests/test_multi_task_prior.py
+++ b/tests/test_multi_task_prior.py
@@ -1,0 +1,22 @@
+import torch
+
+from pfns.priors import multi_task_gp
+
+
+def test_multi_task_prior_shapes():
+    torch.manual_seed(1)
+    batch = multi_task_gp.get_batch(
+        batch_size=3,
+        seq_len=8,
+        num_features=5,
+        single_eval_pos=4,
+        device=torch.device("cpu"),
+    )
+
+    assert batch.x.shape == (3, 8, 5)
+    assert batch.y.shape == (3, 8, 1)
+    assert batch.target_y.shape == (3, 8, 1)
+    assert batch.task_partition is not None
+    assert batch.task_partition.shape == (3, 8)
+    # ensure multiple tasks present in batch
+    assert batch.task_partition.unique().numel() > 1


### PR DESCRIPTION
## Summary
- stabilize the LKJ-based multi-task GP sampler by symmetrizing covariances and escalating jitter when forming the Cholesky factor

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d0d8c933308327a45270082073aacc